### PR TITLE
Log test runs to database

### DIFF
--- a/microservice-testing-lab/agents/api-testing/user-service-api-tests/pom.xml
+++ b/microservice-testing-lab/agents/api-testing/user-service-api-tests/pom.xml
@@ -26,6 +26,18 @@
         <artifactId>spring-boot-starter-test</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/java/com/kb/testing/DbTestReportingExtension.java
+++ b/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/java/com/kb/testing/DbTestReportingExtension.java
@@ -1,0 +1,149 @@
+package com.kb.testing;
+
+import org.junit.jupiter.api.extension.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+public class DbTestReportingExtension implements TestWatcher, BeforeAllCallback, AfterAllCallback, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+	private static final String JDBC_URL = System.getenv("TEST_RESULTS_JDBC_URL");
+	private static final String JDBC_USER = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_USER")).orElse("");
+	private static final String JDBC_PASSWORD = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_PASSWORD")).orElse("");
+	private static final String SERVICE_NAME = Optional.ofNullable(System.getenv("TEST_RESULTS_SERVICE_NAME")).orElse("user-service");
+	private static final String TEST_TYPE = Optional.ofNullable(System.getenv("TEST_RESULTS_TEST_TYPE")).orElse("API_TEST");
+
+	private static final boolean REPORTING_ENABLED = JDBC_URL != null && !JDBC_URL.isBlank();
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		if (!REPORTING_ENABLED) return;
+		try (Connection connection = getConnection()) {
+			ensureTableExists(connection);
+		} catch (Exception ignored) {
+			// Swallow to not break tests
+		}
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		// no-op
+	}
+
+	@Override
+	public void beforeTestExecution(ExtensionContext context) {
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		store.put("start", Instant.now());
+	}
+
+	@Override
+	public void afterTestExecution(ExtensionContext context) {
+		// no-op, handled in TestWatcher callbacks for status
+	}
+
+	@Override
+	public void testSuccessful(ExtensionContext context) {
+		record(context, "PASSED", null);
+	}
+
+	@Override
+	public void testFailed(ExtensionContext context, Throwable cause) {
+		record(context, "FAILED", cause);
+	}
+
+	@Override
+	public void testAborted(ExtensionContext context, Throwable cause) {
+		record(context, "SKIPPED", cause);
+	}
+
+	private void record(ExtensionContext context, String status, Throwable error) {
+		if (!REPORTING_ENABLED) return;
+		String testName = context.getRequiredTestClass().getSimpleName() + "." + context.getDisplayName();
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		Instant start = store.get("start", Instant.class);
+		Instant end = Instant.now();
+		long durationMs = start != null ? Duration.between(start, end).toMillis() : 0L;
+
+		try (Connection connection = getConnection()) {
+			insertResult(connection, testName, SERVICE_NAME, TEST_TYPE, status, durationMs, Timestamp.from(start != null ? start : end), Timestamp.from(end), error);
+		} catch (Exception ignored) {
+			// Do not fail tests due to reporting issues
+		}
+	}
+
+	private static Connection getConnection() throws SQLException {
+		if (JDBC_USER.isEmpty() && JDBC_PASSWORD.isEmpty()) {
+			return DriverManager.getConnection(JDBC_URL);
+		}
+		return DriverManager.getConnection(JDBC_URL, JDBC_USER, JDBC_PASSWORD);
+	}
+
+	private static void ensureTableExists(Connection connection) throws SQLException {
+		final String sql = "CREATE TABLE IF NOT EXISTS test_results (" +
+			"id UUID PRIMARY KEY," +
+			"test_name VARCHAR(255) NOT NULL," +
+			"service_name VARCHAR(255) NOT NULL," +
+			"test_type VARCHAR(50) NOT NULL," +
+			"status VARCHAR(50) NOT NULL," +
+			"execution_time_ms BIGINT," +
+			"start_time TIMESTAMP NOT NULL," +
+			"end_time TIMESTAMP," +
+			"error_message TEXT," +
+			"stack_trace TEXT," +
+			"created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"updated_at TIMESTAMP" +
+		")";
+		try (PreparedStatement ps = connection.prepareStatement(sql)) {
+			ps.execute();
+		}
+	}
+
+	private static void insertResult(
+			Connection connection,
+			String testName,
+			String serviceName,
+			String testType,
+			String status,
+			long executionTimeMs,
+			Timestamp startTime,
+			Timestamp endTime,
+			Throwable error
+	) throws SQLException {
+		final String insert = "INSERT INTO test_results (" +
+			"id, test_name, service_name, test_type, status, execution_time_ms, start_time, end_time, error_message, stack_trace, updated_at" +
+			") VALUES (?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP)";
+		try (PreparedStatement ps = connection.prepareStatement(insert)) {
+			ps.setObject(1, java.util.UUID.randomUUID());
+			ps.setString(2, testName);
+			ps.setString(3, serviceName);
+			ps.setString(4, testType);
+			ps.setString(5, status);
+			ps.setLong(6, executionTimeMs);
+			ps.setTimestamp(7, startTime);
+			ps.setTimestamp(8, endTime);
+			ps.setString(9, error != null ? safeTruncate(error.getMessage(), 2000) : null);
+			ps.setString(10, error != null ? safeTruncate(getStackTraceAsString(error), 8000) : null);
+			ps.executeUpdate();
+		}
+	}
+
+	private static String safeTruncate(String s, int max) {
+		if (s == null) return null;
+		return s.length() <= max ? s : s.substring(0, max);
+	}
+
+	private static String getStackTraceAsString(Throwable t) {
+		StringBuilder sb = new StringBuilder();
+		for (StackTraceElement e : t.getStackTrace()) {
+			sb.append(e.toString()).append('\n');
+		}
+		return sb.toString();
+	}
+}
+

--- a/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.kb.testing.DbTestReportingExtension

--- a/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/resources/junit-platform.properties
+++ b/microservice-testing-lab/agents/api-testing/user-service-api-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/microservice-testing-lab/agents/contract-testing/user-service-consumer/pom.xml
+++ b/microservice-testing-lab/agents/contract-testing/user-service-consumer/pom.xml
@@ -20,5 +20,17 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.14</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/java/com/kb/testing/DbTestReportingExtension.java
+++ b/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/java/com/kb/testing/DbTestReportingExtension.java
@@ -1,0 +1,117 @@
+package com.kb.testing;
+
+import org.junit.jupiter.api.extension.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+public class DbTestReportingExtension implements TestWatcher, BeforeAllCallback, AfterAllCallback, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+	private static final String JDBC_URL = System.getenv("TEST_RESULTS_JDBC_URL");
+	private static final String JDBC_USER = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_USER")).orElse("");
+	private static final String JDBC_PASSWORD = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_PASSWORD")).orElse("");
+	private static final String SERVICE_NAME = Optional.ofNullable(System.getenv("TEST_RESULTS_SERVICE_NAME")).orElse("user-service");
+	private static final String TEST_TYPE = Optional.ofNullable(System.getenv("TEST_RESULTS_TEST_TYPE")).orElse("CONTRACT_TEST");
+
+	private static final boolean REPORTING_ENABLED = JDBC_URL != null && !JDBC_URL.isBlank();
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		if (!REPORTING_ENABLED) return;
+		try (Connection connection = getConnection()) {
+			ensureTableExists(connection);
+		} catch (Exception ignored) {
+		}
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {}
+
+	@Override
+	public void beforeTestExecution(ExtensionContext context) {
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		store.put("start", Instant.now());
+	}
+
+	@Override
+	public void afterTestExecution(ExtensionContext context) {}
+
+	@Override
+	public void testSuccessful(ExtensionContext context) { record(context, "PASSED", null); }
+
+	@Override
+	public void testFailed(ExtensionContext context, Throwable cause) { record(context, "FAILED", cause); }
+
+	@Override
+	public void testAborted(ExtensionContext context, Throwable cause) { record(context, "SKIPPED", cause); }
+
+	private void record(ExtensionContext context, String status, Throwable error) {
+		if (!REPORTING_ENABLED) return;
+		String testName = context.getRequiredTestClass().getSimpleName() + "." + context.getDisplayName();
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		Instant start = store.get("start", Instant.class);
+		Instant end = Instant.now();
+		long durationMs = start != null ? Duration.between(start, end).toMillis() : 0L;
+
+		try (Connection connection = getConnection()) {
+			insertResult(connection, testName, SERVICE_NAME, TEST_TYPE, status, durationMs, Timestamp.from(start != null ? start : end), Timestamp.from(end), error);
+		} catch (Exception ignored) {}
+	}
+
+	private static Connection getConnection() throws SQLException {
+		if (JDBC_USER.isEmpty() && JDBC_PASSWORD.isEmpty()) {
+			return DriverManager.getConnection(JDBC_URL);
+		}
+		return DriverManager.getConnection(JDBC_URL, JDBC_USER, JDBC_PASSWORD);
+	}
+
+	private static void ensureTableExists(Connection connection) throws SQLException {
+		final String sql = "CREATE TABLE IF NOT EXISTS test_results (" +
+			"id UUID PRIMARY KEY," +
+			"test_name VARCHAR(255) NOT NULL," +
+			"service_name VARCHAR(255) NOT NULL," +
+			"test_type VARCHAR(50) NOT NULL," +
+			"status VARCHAR(50) NOT NULL," +
+			"execution_time_ms BIGINT," +
+			"start_time TIMESTAMP NOT NULL," +
+			"end_time TIMESTAMP," +
+			"error_message TEXT," +
+			"stack_trace TEXT," +
+			"created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"updated_at TIMESTAMP" +
+		")";
+		try (PreparedStatement ps = connection.prepareStatement(sql)) { ps.execute(); }
+	}
+
+	private static void insertResult(Connection connection, String testName, String serviceName, String testType, String status, long executionTimeMs, Timestamp startTime, Timestamp endTime, Throwable error) throws SQLException {
+		final String insert = "INSERT INTO test_results (id, test_name, service_name, test_type, status, execution_time_ms, start_time, end_time, error_message, stack_trace, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP)";
+		try (PreparedStatement ps = connection.prepareStatement(insert)) {
+			ps.setObject(1, java.util.UUID.randomUUID());
+			ps.setString(2, testName);
+			ps.setString(3, serviceName);
+			ps.setString(4, testType);
+			ps.setString(5, status);
+			ps.setLong(6, executionTimeMs);
+			ps.setTimestamp(7, startTime);
+			ps.setTimestamp(8, endTime);
+			ps.setString(9, error != null ? safeTruncate(error.getMessage(), 2000) : null);
+			ps.setString(10, error != null ? safeTruncate(getStackTraceAsString(error), 8000) : null);
+			ps.executeUpdate();
+		}
+	}
+
+	private static String safeTruncate(String s, int max) { return s == null ? null : (s.length() <= max ? s : s.substring(0, max)); }
+
+	private static String getStackTraceAsString(Throwable t) {
+		StringBuilder sb = new StringBuilder();
+		for (StackTraceElement e : t.getStackTrace()) { sb.append(e).append('\n'); }
+		return sb.toString();
+	}
+}
+

--- a/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.kb.testing.DbTestReportingExtension

--- a/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/resources/junit-platform.properties
+++ b/microservice-testing-lab/agents/contract-testing/user-service-consumer/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/microservice-testing-lab/agents/contract-testing/user-service-provider/pom.xml
+++ b/microservice-testing-lab/agents/contract-testing/user-service-provider/pom.xml
@@ -20,6 +20,18 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/java/com/kb/testing/DbTestReportingExtension.java
+++ b/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/java/com/kb/testing/DbTestReportingExtension.java
@@ -1,0 +1,112 @@
+package com.kb.testing;
+
+import org.junit.jupiter.api.extension.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+public class DbTestReportingExtension implements TestWatcher, BeforeAllCallback, AfterAllCallback, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+	private static final String JDBC_URL = System.getenv("TEST_RESULTS_JDBC_URL");
+	private static final String JDBC_USER = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_USER")).orElse("");
+	private static final String JDBC_PASSWORD = Optional.ofNullable(System.getenv("TEST_RESULTS_DB_PASSWORD")).orElse("");
+	private static final String SERVICE_NAME = Optional.ofNullable(System.getenv("TEST_RESULTS_SERVICE_NAME")).orElse("user-service");
+	private static final String TEST_TYPE = Optional.ofNullable(System.getenv("TEST_RESULTS_TEST_TYPE")).orElse("CONTRACT_TEST");
+
+	private static final boolean REPORTING_ENABLED = JDBC_URL != null && !JDBC_URL.isBlank();
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		if (!REPORTING_ENABLED) return;
+		try (Connection connection = getConnection()) { ensureTableExists(connection); } catch (Exception ignored) {}
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {}
+
+	@Override
+	public void beforeTestExecution(ExtensionContext context) {
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		store.put("start", Instant.now());
+	}
+
+	@Override
+	public void afterTestExecution(ExtensionContext context) {}
+
+	@Override
+	public void testSuccessful(ExtensionContext context) { record(context, "PASSED", null); }
+
+	@Override
+	public void testFailed(ExtensionContext context, Throwable cause) { record(context, "FAILED", cause); }
+
+	@Override
+	public void testAborted(ExtensionContext context, Throwable cause) { record(context, "SKIPPED", cause); }
+
+	private void record(ExtensionContext context, String status, Throwable error) {
+		if (!REPORTING_ENABLED) return;
+		String testName = context.getRequiredTestClass().getSimpleName() + "." + context.getDisplayName();
+		ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+		Instant start = store.get("start", Instant.class);
+		Instant end = Instant.now();
+		long durationMs = start != null ? Duration.between(start, end).toMillis() : 0L;
+
+		try (Connection connection = getConnection()) {
+			insertResult(connection, testName, SERVICE_NAME, TEST_TYPE, status, durationMs, Timestamp.from(start != null ? start : end), Timestamp.from(end), error);
+		} catch (Exception ignored) {}
+	}
+
+	private static Connection getConnection() throws SQLException {
+		if (JDBC_USER.isEmpty() && JDBC_PASSWORD.isEmpty()) { return DriverManager.getConnection(JDBC_URL); }
+		return DriverManager.getConnection(JDBC_URL, JDBC_USER, JDBC_PASSWORD);
+	}
+
+	private static void ensureTableExists(Connection connection) throws SQLException {
+		final String sql = "CREATE TABLE IF NOT EXISTS test_results (" +
+			"id UUID PRIMARY KEY," +
+			"test_name VARCHAR(255) NOT NULL," +
+			"service_name VARCHAR(255) NOT NULL," +
+			"test_type VARCHAR(50) NOT NULL," +
+			"status VARCHAR(50) NOT NULL," +
+			"execution_time_ms BIGINT," +
+			"start_time TIMESTAMP NOT NULL," +
+			"end_time TIMESTAMP," +
+			"error_message TEXT," +
+			"stack_trace TEXT," +
+			"created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+			"updated_at TIMESTAMP" +
+		")";
+		try (PreparedStatement ps = connection.prepareStatement(sql)) { ps.execute(); }
+	}
+
+	private static void insertResult(Connection connection, String testName, String serviceName, String testType, String status, long executionTimeMs, Timestamp startTime, Timestamp endTime, Throwable error) throws SQLException {
+		final String insert = "INSERT INTO test_results (id, test_name, service_name, test_type, status, execution_time_ms, start_time, end_time, error_message, stack_trace, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP)";
+		try (PreparedStatement ps = connection.prepareStatement(insert)) {
+			ps.setObject(1, java.util.UUID.randomUUID());
+			ps.setString(2, testName);
+			ps.setString(3, serviceName);
+			ps.setString(4, testType);
+			ps.setString(5, status);
+			ps.setLong(6, executionTimeMs);
+			ps.setTimestamp(7, startTime);
+			ps.setTimestamp(8, endTime);
+			ps.setString(9, error != null ? safeTruncate(error.getMessage(), 2000) : null);
+			ps.setString(10, error != null ? safeTruncate(getStackTraceAsString(error), 8000) : null);
+			ps.executeUpdate();
+		}
+	}
+
+	private static String safeTruncate(String s, int max) { return s == null ? null : (s.length() <= max ? s : s.substring(0, max)); }
+
+	private static String getStackTraceAsString(Throwable t) {
+		StringBuilder sb = new StringBuilder();
+		for (StackTraceElement e : t.getStackTrace()) { sb.append(e).append('\n'); }
+		return sb.toString();
+	}
+}
+

--- a/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.kb.testing.DbTestReportingExtension

--- a/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/resources/junit-platform.properties
+++ b/microservice-testing-lab/agents/contract-testing/user-service-provider/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
Add JUnit 5 extensions to test agents for database test result reporting.

This PR implements a JUnit 5 `TestWatcher` extension in the `user-service-api-tests`, `user-service-consumer`, and `user-service-provider` modules. It automatically captures test execution details (status, duration, errors) and persists them to a `test_results` table via JDBC. The extension is configured via environment variables and auto-discovered by the JUnit Platform, requiring no modifications to existing test classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-75f63b40-675d-4929-a0ba-72c40198bdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75f63b40-675d-4929-a0ba-72c40198bdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

